### PR TITLE
Remove initial export from ccc snippet

### DIFF
--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -35,7 +35,7 @@
   "Class Component With State": {
     "prefix": "ccc",
     "body": [
-      "export class $1 extends Component {",
+      "class $1 extends Component {",
       "\tconstructor(props) {",
       "\t\tsuper(props);",
       "\t\tthis.state = { $2 }",


### PR DESCRIPTION
I'm not sure if you had intended to export the `ccc` component twice, but I noticed issue #9 so I thought I'd make a PR to address it. If that was intentional, please disregard this PR. Have a great day!