### PR TITLE
SFC is deprecated, use React.FunctionComponent instead

### DIFF
--- a/snippets/snippets-ts.json
+++ b/snippets/snippets-ts.json
@@ -76,7 +76,7 @@
       "\t$2",
       "}",
       " ",
-      "const $1: React.SFC<$1Props> = ($3) => {",
+      "const $1: React.FunctionComponent<$1Props> = ($3) => {",
       "\treturn ( $0 );",
       "}",
       " ",


### PR DESCRIPTION
Thanks for a great plugin, please could you update, based on https://stackoverflow.com/questions/53885993/react-16-7-react-sfc-is-now-deprecated