### PR TITLE
Rename React.SFC type to React.FC due to React.SFC is deprecated

### DIFF
--- a/snippets/snippets-ts.json
+++ b/snippets/snippets-ts.json
@@ -76,7 +76,7 @@
       "\t$2",
       "}",
       " ",
-      "const $1: React.SFC<$1Props> = ($3) => {",
+      "const $1: React.FC<$1Props> = ($3) => {",
       "\treturn ( $0 );",
       "}",
       " ",

--- a/snippets/snippets-ts.json
+++ b/snippets/snippets-ts.json
@@ -69,7 +69,7 @@
     "description": "Class Component with Constructor"
   },
 
-  "Stateless Function Component": {
+  "Function Component": {
     "prefix": "sfc",
     "body": [
       "export interface $1Props {",
@@ -82,7 +82,7 @@
       " ",
       "export default $1;"
     ],
-    "description": "Stateless Function Component"
+    "description": "Function Component"
   },
 
   "componentDidMount": {


### PR DESCRIPTION
Currently, `sfc` snippet generates functional component with React.SFC type which is a deprecated type.
ref: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/30364

It motivates me to open this PR. It simply rename `React.SFC` to `React.FC`