### PR TITLE
Fix documentation for cpc

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ class | extends Component {
 export default |;
 ```
 
-### ccc - Class Component With Constructor
+### cpc - Class Pure Component
 
 ```javascript
 class | extends PureComponent {


### PR DESCRIPTION
Documentation makes reference to `ccc` and `Class Component with Constructor` for the `Class Pure Component` code snippet.