### PR TITLE
feat: Add 'sfc' for Typescript

### DIFF
--- a/snippets/snippets-ts.json
+++ b/snippets/snippets-ts.json
@@ -143,6 +143,18 @@
     ],
     "description": "Function Syntax Component"
   },
+
+  "Stateless Function Component": {
+    "prefix": "sfc",
+    "body": [
+      "const $1 = ($2) => {",
+      "\treturn ( $0 );",
+      "}",
+      " ",
+      "export default $1;"
+    ],
+    "description": "Stateless Function Component"
+  },
   
   "componentDidMount": {
     "prefix": "cdm",


### PR DESCRIPTION
As reported in [Issue #74](https://github.com/burkeholland/simple-react-snippets/issues/74), `sfc` (Stateless Functional Component: Arrow Function) was not working for Typescript. The JSON fragment for Javascript was copied to the Typescript file and it now works

This was tested in `Extension Development Host` for VSCode
