### PR TITLE
feat: add 'effc' for Function Syntax Component Inline

### DIFF
--- a/snippets/snippets-ts.json
+++ b/snippets/snippets-ts.json
@@ -155,7 +155,7 @@
     ],
     "description": "Stateless Function Component"
   },
-  
+
   "componentDidMount": {
     "prefix": "cdm",
     "body": ["componentDidMount() {", "\t$0", "}"],
@@ -273,5 +273,15 @@
       "export default $1;"
     ],
     "description": "Render Prop"
+  },
+
+  "Function Syntax Component Inline": {
+    "prefix": "effc",
+    "body": [
+      "export default function $1($2) {",
+      "\treturn ( $0 );",
+      "}"
+    ],
+    "description": "Function Syntax Component Inline"
   }
 }

--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -116,7 +116,7 @@
     ],
     "description": "Function Syntax Component"
   },
-  
+
   "componentDidMount": {
     "prefix": "cdm",
     "body": ["componentDidMount() {", "\t$0", "}"],
@@ -271,7 +271,7 @@
     ],
     "description": "Context Provider"
   },
-  
+
   "Class Property Function": {
     "prefix": "cpf",
     "body": [
@@ -280,5 +280,15 @@
       "};"
     ],
     "description": "Class Property Function"
+  },
+
+  "Function Syntax Component Inline": {
+    "prefix": "effc",
+    "body": [
+      "export default function $1($2) {",
+      "\treturn ( $0 );",
+      "}"
+    ],
+    "description": "Function Syntax Component Inline"
   }
 }


### PR DESCRIPTION
Snippet for Function Syntax Component, but it exports the function in the same line it is defined, different from the existing '`ffc`'.

Resolves #88.